### PR TITLE
Add event parameter in the readme usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ generateEventTypes({FooEvent});
 
 // listener for events
 const foo = new Foo();
-const exampleHandler = () => 
+const exampleHandler = (event:FooEvent) => 
 {
-  console.log('Handler called!');
+  console.log('Handler called!', event.type, event.target);
 }
 foo.addEventListener(FooEvent.COMPLETE, exampleHandler);
 


### PR DESCRIPTION
Makes it clear that the event you are dispatching, is passed as only argument in the event handler, and can be used to retrieve the type and target.
