### PR TITLE
Install npm 3 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
 sudo: false
 
 before_install:
+  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
   - npm install -g typings
   - npm install -g codeclimate-test-reporter
 


### PR DESCRIPTION
Node 4 comes bundled with npm 2, but we want to use npm 3 for all our code.
On of the issues of npm 2 is that incorrect peerDependencies result in an error, while the actual code might work just fine.

This addition checks the npm version before running anything, and installs version 3 if it's not already installed.
