### PR TITLE
Fix EventHandler typings

### DIFF
--- a/src/lib/EventDispatcher.ts
+++ b/src/lib/EventDispatcher.ts
@@ -389,4 +389,4 @@ type EventListenerMap = { [type: string]: Array<EventListenerData> };
 /**
  * Type alias for event handler functions that can be passed to [[EventDispatcher.addEventListener]]
  */
-export type EventHandler = (event?: IEvent) => any;
+export type EventHandler = (event: IEvent) => any;


### PR DESCRIPTION
Event parameter is always passed, so it shouldn't be optional

Closes #14 