### PR TITLE
Export types from module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seng-event",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Provides Classes and utilities for dispatching and listening to events.",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@
  */
 import { default as _export } from './lib/EventDispatcher';
 
+export * from './lib/types';
 export { default as createEventClass } from './lib/createEventClass';
 export { default as createIsomorphicEventClass } from './lib/createIsomorphicEventClass';
 export { default as EventPhase } from './lib/EventPhase';

--- a/src/lib/createEventClass.ts
+++ b/src/lib/createEventClass.ts
@@ -2,19 +2,7 @@
  * @module seng-event
  */
 import BaseEvent from './BaseEvent';
-
-/**
- * @ignore
- */
-type TypeMap<TType extends string> = { [P in TType]: P };
-
-/**
- * @ignore
- */
-interface EventTypeClass<TData, TType extends string> {
-  types: TypeMap<TType>;
-  new (type: TType, data: TData): BaseEvent<TData, TType>;
-}
+import { EventTypeClass, TypeMap } from './types';
 
 /**
  * Utility function to generate a class that extends [[AbstractEvent]] and optionally has

--- a/src/lib/createIsomorphicEventClass.ts
+++ b/src/lib/createIsomorphicEventClass.ts
@@ -3,11 +3,7 @@
  */
 import { DataForIsomorphicEvent } from './EventTypings';
 import IsomorphicBaseEvent, { EventOptions, EventOptionsMap } from './IsomorphicBaseEvent';
-
-/**
- * @ignore
- */
-type TypeMap<TType extends string> = { [P in TType]: P };
+import { TypeMap } from './types';
 
 /**
  * Advanced variant of the [[createEventClass]] util. Creates an _isomorphic_ event class.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,14 @@
+import BaseEvent from './BaseEvent';
+
+/**
+ * @ignore
+ */
+export type TypeMap<TType extends string> = { [P in TType]: P };
+
+/**
+ * @ignore
+ */
+export interface EventTypeClass<TData, TType extends string> {
+  types: TypeMap<TType>;
+  new (type: TType, data: TData): BaseEvent<TData, TType>;
+}


### PR DESCRIPTION
This is to prevent a TS4020 error, where TypeScript is trying to look up the name of a type but they are considered private because they are not exported from the module.
Fixes #35 