### PR TITLE
Fix `.data` property in `IsomorphicBaseEvent`

### DIFF
--- a/src/lib/IsomorphicBaseEvent.ts
+++ b/src/lib/IsomorphicBaseEvent.ts
@@ -46,6 +46,7 @@ class IsomorphicBaseEvent<
     super(type, data, bubbles, cancelable, setTimeStamp);
     this.typeOptions = typeOptions;
     this.type = type;
+    this.data = data;
   }
 
   public clone(): IsomorphicBaseEvent<TTypes, TDataTypes, TType> {

--- a/test/createIsomorphicEventClass.spec.ts
+++ b/test/createIsomorphicEventClass.spec.ts
@@ -12,7 +12,7 @@ describe('createIsomorphicEventClass', () => {
 
     class IsoPlayerEvent<T extends 'PLAY' | 'STOP' | 'UPDATE'> extends createIsomorphicEventClass<
       [PlayerEventData, PlayerEventData, PlayerUpdateEventData]
-      >({ cancelable: true })('PLAY', 'STOP', 'UPDATE')<T> {}
+    >({ cancelable: true })('PLAY', 'STOP', 'UPDATE')<T> {}
 
     const playEvent = new IsoPlayerEvent('PLAY', { playerId: 1 });
     expect(playEvent.cancelable).toBe(true);
@@ -46,10 +46,26 @@ describe('createIsomorphicEventClass', () => {
 
     class IsoPlayerEvent<T extends 'PLAY' | 'STOP' | 'UPDATE'> extends createIsomorphicEventClass<
       [PlayerEventData, PlayerEventData, PlayerUpdateEventData]
-      >({ cancelable: true })('PLAY', 'STOP', 'UPDATE')<T> {}
+    >({ cancelable: true })('PLAY', 'STOP', 'UPDATE')<T> {}
 
     const playEvent = new IsoPlayerEvent('PLAY', { playerId: 1 });
     const playEvent2 = playEvent.clone();
     expect(playEvent).not.toBe(playEvent2);
+  });
+  it('should contain passed event data', () => {
+    interface PlayerEventData {
+      playerId: number;
+    }
+
+    interface PlayerUpdateEventData extends PlayerEventData {
+      currentTime: number;
+    }
+
+    class IsoPlayerEvent<T extends 'PLAY' | 'STOP' | 'UPDATE'> extends createIsomorphicEventClass<
+      [PlayerEventData, PlayerEventData, PlayerUpdateEventData]
+    >({ cancelable: true })('PLAY', 'STOP', 'UPDATE')<T> {}
+
+    const playEvent = new IsoPlayerEvent('PLAY', { playerId: 1 });
+    expect(playEvent.data).toEqual({ playerId: 1 });
   });
 });


### PR DESCRIPTION
Set the `.data` property again (even though it's already defined in the base class). This is related to this issue the [new declaration behavior for class fields](
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier).

It seems to be that things are running fine when compiling, but if running in jest or ts-node, the behavior described in `useDefineForClassFields` will be used instead. This will cause
the specialization of the data property to a sub-type in `IsomorphicBaseEvent` to actually re-declare the property as `undefined`.

Note: we could use the `declare` keyword here as well, but that would require a typescript update to 3.7. This seems to be the most straightforward solution

Closes #50