### PR TITLE
Fix example of event with data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 # seng-event
 Provides Classes and utilities for dispatching and listening to events.
 
-Provides an _EventDispatcher_ base class that adds the ability to dispatch events and attach handlers that 
+Provides an _EventDispatcher_ base class that adds the ability to dispatch events and attach handlers that
 should be called when such events are triggered. New event classes can be created by extending the _AbstractEvent_
 class provided in this module. This module also provides basic event classes _BasicEvent_ and _CommonEvent_ that
 are ready to be used with _EventDispatcher_.
 
-_seng-event_ also supports event capturing and bubbling phases, heavily inspired by existing event 
-dispatching systems like the functionality described in the 
+_seng-event_ also supports event capturing and bubbling phases, heavily inspired by existing event
+dispatching systems like the functionality described in the
 [DOM Event W3 spec](https://www.w3.org/TR/DOM-Level-2-Events/events.html)
 
 ## Installation
@@ -29,7 +29,7 @@ npm i -S seng-event
 
 ### 1. Extend the EventDispatcher class
 By extending `EventDispatcher`, your class gains the ability to dispatch events using `this.dispatchEvent()`. Other code
-can listen to events by calling the `addEventListener()` method on your class. For more methods, see the generated 
+can listen to events by calling the `addEventListener()` method on your class. For more methods, see the generated
 [API Docs](https://mediamonks.github.io/seng-event/)
 
 ```ts
@@ -62,7 +62,7 @@ class DogEvent extends AbstractEvent {
       RUN: 'RUN',
       WALK: 'WALK'
    };
-   
+
    public clone():DogEvent {
        return new DogEvent(this.type);
    }
@@ -79,7 +79,7 @@ const runHandler = (event:DogEvent) => {
 dog.addEventListener(DogEvent.types.RUN, runHandler);
 
 // dispatch an event (will execute runHandler and log 'Dog is running!')
-dog.dispatchEvent(new DogEvent(DogEvent.types.RUN));  
+dog.dispatchEvent(new DogEvent(DogEvent.types.RUN));
 ```
 
 ## Binding your EventDispatcher child class to certain event classes
@@ -108,7 +108,7 @@ this.dispatchEvent(new DogEvent(DogEvent.types.JUMP, { mood: 'happy' }));
 ```ts
 // accessing the data
 dog.addEventListener(DogEvent.types.JUMP, event => {
-  console.log(`Dog jumped in a ${event.mood} mood!`);
+  console.log(`Dog jumped in a ${event.data.mood} mood!`);
 });
 ```
 
@@ -149,7 +149,7 @@ class CustomElement extends EventDispatcher<ElementEvent> {
   public name: string;
   constructor(name: string, parent: CustomElement|null = null) {
       super(parent);
-      
+
       this.name = name;
   }
   ...


### PR DESCRIPTION
Changes the example of where to find the data when using data events. (my editor has also reformatted and removed some spaces here and there)